### PR TITLE
Fix storage import error

### DIFF
--- a/grafcli/storage/api.py
+++ b/grafcli/storage/api.py
@@ -2,7 +2,7 @@ import os
 import requests
 from climb.config import config
 
-from grafcli.storage import Storage
+from grafcli.storage.storage import Storage
 from grafcli.documents import Dashboard
 from grafcli.exceptions import DocumentNotFound
 

--- a/grafcli/storage/system.py
+++ b/grafcli/storage/system.py
@@ -4,7 +4,7 @@ from climb.config import config
 
 from grafcli.documents import Dashboard
 from grafcli.exceptions import DocumentNotFound
-from grafcli.storage import Storage
+from grafcli.storage.storage import Storage
 
 
 def data_dir():


### PR DESCRIPTION
Fix for:
```python
ImportError: cannot import name 'Storage' from 'grafcli.storage' 
(/Users/username/.virtualenvs/webrtc-stats/src/grafcli/grafcli/storage/__init__.py)
```